### PR TITLE
Add DartDoc Automated Documentation Generation

### DIFF
--- a/.github/workflows/dartdoc.yml
+++ b/.github/workflows/dartdoc.yml
@@ -2,7 +2,7 @@ name: Build and Deploy Docs
 
 on:
   push:
-    branches: [ * ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/dartdoc.yml
+++ b/.github/workflows/dartdoc.yml
@@ -28,8 +28,11 @@ jobs:
 
       - name: Build docs
         run: dartdoc
-
-      - run:
-          name: Deploy to GitHub Pages
-          command: gh-pages --dist docs/api/
-          
+        
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./doc/api
+        
+        

--- a/.github/workflows/dartdoc.yml
+++ b/.github/workflows/dartdoc.yml
@@ -1,11 +1,8 @@
 name: Build and Deploy Docs
 
 on:
-  workflow_run:
-    workflows: [ "Build, Format, Test" ]
+  push:
     branches: [ main ]
-    types:
-      - completed
 
 jobs:
   build:

--- a/.github/workflows/dartdoc.yml
+++ b/.github/workflows/dartdoc.yml
@@ -1,8 +1,11 @@
 name: Build and Deploy Docs
 
 on:
-  push:
+  workflow_run:
+    workflows: [ "Build, Format, Test" ]
     branches: [ main ]
+    types:
+      - completed
 
 jobs:
   build:

--- a/.github/workflows/dartdoc.yml
+++ b/.github/workflows/dartdoc.yml
@@ -1,0 +1,35 @@
+name: Build and Deploy Docs
+
+on:
+  push:
+    branches: [ * ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    # Note that this workflow uses the latest stable version of the Dart SDK.
+    # Docker images for other release channels - like dev and beta - are also
+    # available. See https://hub.docker.com/r/cirrusci/flutter for the available
+    # images.
+    container:
+      image:  cirrusci/flutter:latest
+
+    steps:
+      
+      - name: Print Flutter version
+        run: which flutter
+        
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+        
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build docs
+        run: dartdoc
+
+      - run:
+          name: Deploy to GitHub Pages
+          command: gh-pages --dist docs/api/
+          


### PR DESCRIPTION
The documentation will build when any commit/pr is pushed to main.  The docs will be auto-generated and deployed to GitHub pages via the gh-pages branch.

Closes #4 